### PR TITLE
ZIP Legacy encryption support

### DIFF
--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -63,7 +63,11 @@ private:
 
 	FileAccess::CreateFunc fa_create_func;
 
+	CharString password;
+
 public:
+	void set_password(const CharString &pass); // set or clear the zip legacy encryption password
+
 	void close_handle(unzFile p_file) const;
 	unzFile get_file_handle(String p_file) const;
 

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -34,6 +34,7 @@
 #include "core/core_string_names.h"
 #include "core/io/file_access_network.h"
 #include "core/io/file_access_pack.h"
+#include "core/io/file_access_zip.h"
 #include "core/io/marshalls.h"
 #include "core/os/dir_access.h"
 #include "core/os/file_access.h"
@@ -298,7 +299,7 @@ void ProjectSettings::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
-bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset) {
+bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset, const String &p_password) {
 	if (PackedData::get_singleton()->is_disabled()) {
 		return false;
 	}
@@ -312,6 +313,9 @@ bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_f
 	//if data.pck is found, all directory access will be from here
 	DirAccess::make_default<DirAccessPack>(DirAccess::ACCESS_RESOURCES);
 	using_datapack = true;
+
+	//set or clear ZipArchive password
+	ZipArchive::get_singleton()->set_password(p_password.utf8());
 
 	return true;
 }
@@ -1036,7 +1040,7 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("localize_path", "path"), &ProjectSettings::localize_path);
 	ClassDB::bind_method(D_METHOD("globalize_path", "path"), &ProjectSettings::globalize_path);
 	ClassDB::bind_method(D_METHOD("save"), &ProjectSettings::save);
-	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset"), &ProjectSettings::_load_resource_pack, DEFVAL(true), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset", "password"), &ProjectSettings::_load_resource_pack, DEFVAL(true), DEFVAL(0), DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("property_can_revert", "name"), &ProjectSettings::property_can_revert);
 	ClassDB::bind_method(D_METHOD("property_get_revert", "name"), &ProjectSettings::property_get_revert);
 

--- a/core/project_settings.h
+++ b/core/project_settings.h
@@ -138,7 +138,7 @@ protected:
 
 	void _convert_to_last_version(int p_from_version);
 
-	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true, int p_offset = 0);
+	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true, int p_offset = 0, const String &p_password="");
 
 	void _add_property_info_bind(const Dictionary &p_info);
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -96,10 +96,12 @@
 			<argument index="0" name="pack" type="String" />
 			<argument index="1" name="replace_files" type="bool" default="true" />
 			<argument index="2" name="offset" type="int" default="0" />
+			<argument index="3" name="password" type="String" default="" />
 			<description>
 				Loads the contents of the .pck or .zip file specified by [code]pack[/code] into the resource filesystem ([code]res://[/code]). Returns [code]true[/code] on success.
 				[b]Note:[/b] If a file from [code]pack[/code] shares the same path as a file already in the resource filesystem, any attempts to load that file will use the file from [code]pack[/code] unless [code]replace_files[/code] is set to [code]false[/code].
 				[b]Note:[/b] The optional [code]offset[/code] parameter can be used to specify the offset in bytes to the start of the resource pack. This is only supported for .pck files.
+				[b]Note:[/b] The optional [code]password[/code] parameter can be used to specify the encryption password of the resource pack. This is only supported for .zip files, and only supported for ZIP legacy encryption.
 			</description>
 		</method>
 		<method name="localize_path" qualifiers="const">

--- a/thirdparty/minizip/unzip.c
+++ b/thirdparty/minizip/unzip.c
@@ -68,10 +68,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef NOUNCRYPT
-        #define NOUNCRYPT
-#endif
-
 #include "zlib.h"
 #include "unzip.h"
 


### PR DESCRIPTION
Add support for load ZIP Legacy encryption protected resource pack

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.
-->
